### PR TITLE
Close #4 - Use Perl Artistic license

### DIFF
--- a/META.json
+++ b/META.json
@@ -6,7 +6,7 @@
    "dynamic_config" : 0,
    "generated_by" : "Minilla/v2.4.1, CPAN::Meta::Converter version 2.142690",
    "license" : [
-      "unknown"
+      "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Perl, and it's not hiding how it's working.
 # AUTHOR
 
 Philip Horger <campadrenalin@gmail.com>
+
+# LICENSE
+
+        This library is free software; you may redistribute it and/or
+            modify it under the same terms as Perl itself.

--- a/lib/Lintel.pm
+++ b/lib/Lintel.pm
@@ -61,6 +61,11 @@ Perl, and it's not hiding how it's working.
 
 Philip Horger E<lt>campadrenalin@gmail.comE<gt>
 
+=head1 LICENSE
+
+        This library is free software; you may redistribute it and/or
+            modify it under the same terms as Perl itself.
+
 =cut
 
 use FindBin;


### PR DESCRIPTION
While I actually prefer the protections of the LGPL3 license, it's
really onerous and obnoxious to have to include the license info at
the head of every file, and I didn't want to work out how to get
Minilla to infer my license choice.

Bad reasons? Maybe. But LGPL continues to be a deliberate pain in the
ass, so I'm exercising my right to boycott it for shallow reasons.
And because this library isn't that important, it's not the end of
the world if I got this wrong.
